### PR TITLE
Update SLOGOverprovision.md to Fix Broken Link

### DIFF
--- a/content/CORE/CORETutorials/Storage/Pools/SLOGOverprovision.md
+++ b/content/CORE/CORETutorials/Storage/Pools/SLOGOverprovision.md
@@ -15,7 +15,7 @@ The most useful benefit of over-provisioning is greatly extending SSD life.
 Over-provisioning an SSD distributes the total number of writes and erases across more flash blocks on the drive. 
 
 Seagate provides a thoughtful investigation into over-provisioning SSDs here: 
-https://www.seagate.com/tech-insights/ssd-over-provisioning-benefits-master-ti/.
+https://www.seagate.com/blog/ssd-over-provisioning-benefits-master-ti/.
 
 {{< hint type=note >}}
 Some SATA devices are limited to one resize per power cycle.


### PR DESCRIPTION
Updating Link for Seagate SSD Over-Provisioning Benefits article as currently link is broken. This is the same change that was made to the corresponding SCALE document.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
